### PR TITLE
feat: add browser automation skill via playwright-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .env.*
 !.env.example
 wiki/
+.playwright-cli/

--- a/builtin-skills/browser/SKILL.md
+++ b/builtin-skills/browser/SKILL.md
@@ -138,12 +138,16 @@ playwright-cli open https://example.com --headed --persistent --profile=~/.octop
 
 ## Vault Integration
 
-When browsing produces useful information:
+Only file things into the vault when the user asks you to, or when content is directly relevant to an active project or area. Don't save things speculatively.
 
-1. **Save pages as Resources** — If you find a useful article, guide, or reference, save it to the vault using `write_note` in `Resources/`
-2. **Extract and file data** — Use `eval` or `snapshot` to extract text content, then file structured information as knowledge entries
-3. **Save screenshots** — When visual content matters, take a screenshot and note the file path in the vault
-4. **Create knowledge entries** — If you discover information about people, organizations, or terms, save them using `save_knowledge`
+- **Save reference material** — If the user asks you to save an article, guide, or reference, use `write_note` to create a note in `Resources/` with a summary and the source URL.
+- **Save knowledge entries** — Use `save_knowledge` only when you encounter a specific person, organization, or term that's relevant to the user's work and worth indexing for future recall. Don't create entries for every entity you encounter on a page.
+- **Screenshots** — Take screenshots when the user asks, or when visual content is essential to the task (e.g., a chart, a UI state). Note the file path in your response.
+
+### `write_note` vs `save_knowledge`
+
+- **`write_note`**: Creates a freeform markdown note at any vault path. Use for articles, research, project docs, session notes.
+- **`save_knowledge`**: Creates a structured, indexed entry in `Resources/Knowledge/{People|Terms|Organizations}/` with auto-generated frontmatter. These entries are automatically recognized and linked in future conversations. Use sparingly — only for entities the user will want to reference again.
 
 ## Tips
 

--- a/builtin-skills/browser/SKILL.md
+++ b/builtin-skills/browser/SKILL.md
@@ -138,7 +138,7 @@ playwright-cli open https://example.com --headed --persistent --profile=~/.octop
 
 ## Vault Integration
 
-Only file things into the vault when the user asks you to, or when content is directly relevant to an active project or area. Don't save things speculatively.
+Use judgment about what's worth saving. Content that's directly relevant to an active project, area, or ongoing task is worth filing. Don't save every page you visit — save things the user is likely to want to reference again.
 
 - **Save reference material** — If the user asks you to save an article, guide, or reference, use `write_note` to create a note in `Resources/` with a summary and the source URL.
 - **Save knowledge entries** — Use `save_knowledge` only when you encounter a specific person, organization, or term that's relevant to the user's work and worth indexing for future recall. Don't create entries for every entity you encounter on a page.

--- a/builtin-skills/browser/SKILL.md
+++ b/builtin-skills/browser/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: browser
+description: >
+  Web browser automation using playwright-cli. Enables navigating websites,
+  interacting with pages, taking screenshots, extracting content, and managing
+  persistent browser sessions with cookies and login state.
+metadata:
+  author: octopal
+  version: "0.1"
+---
+
+# Browser Automation
+
+You have access to a web browser via `playwright-cli`. Use it when you need to interact with websites beyond what `web_fetch` or `web_search` can do.
+
+## When to Use the Browser
+
+Use `playwright-cli` instead of `web_fetch` when:
+- A website **blocks agentic access** or returns bot-detection pages
+- You need an **interactive flow** (login, form submission, multi-step navigation)
+- The page requires **JavaScript rendering** (SPAs, dynamic content)
+- You need a **screenshot** or **PDF** of a page
+- You need to **persist login state** across multiple visits (cookies, sessions)
+- You need to interact with page elements (click buttons, fill forms, select dropdowns)
+
+Continue using `web_fetch` for simple page reads, API calls, and known-friendly sites.
+
+## Core Workflow
+
+Always use the persistent profile so cookies and login state survive across sessions:
+
+```bash
+# 1. Open a page with persistent profile
+playwright-cli open https://example.com --persistent --profile=~/.octopal/browser-profile
+
+# 2. Take a snapshot to see page structure and element refs
+playwright-cli snapshot
+
+# 3. Interact with the page using element refs from the snapshot
+playwright-cli click e15
+playwright-cli fill e22 "search query"
+playwright-cli press Enter
+
+# 4. Take another snapshot to see the result
+playwright-cli snapshot
+
+# 5. Screenshot if visual content is important
+playwright-cli screenshot
+
+# 6. Close when done
+playwright-cli close
+```
+
+## Named Sessions
+
+Use `-s=NAME` to run multiple browser sessions in parallel:
+
+```bash
+playwright-cli -s=research open https://example.com --persistent --profile=~/.octopal/browser-profile
+playwright-cli -s=shopping open https://store.com --persistent --profile=~/.octopal/browser-profile
+playwright-cli list                    # see all active sessions
+playwright-cli -s=research snapshot    # interact with specific session
+```
+
+## Incognito Mode
+
+Omit `--persistent` for a temporary session with no saved state:
+
+```bash
+playwright-cli open https://example.com   # ephemeral — cookies lost on close
+```
+
+## Command Reference
+
+### Navigation
+```bash
+playwright-cli open [url]              # open browser, optionally navigate
+playwright-cli goto <url>              # navigate to URL
+playwright-cli go-back                 # browser back button
+playwright-cli go-forward              # browser forward button
+playwright-cli reload                  # refresh page
+```
+
+### Page Interaction
+```bash
+playwright-cli snapshot                # get page structure with element refs
+playwright-cli click <ref>             # click an element
+playwright-cli fill <ref> <text>       # clear and fill text into input
+playwright-cli type <text>             # type text (appends to focused element)
+playwright-cli select <ref> <value>    # select dropdown option
+playwright-cli check <ref>             # check a checkbox
+playwright-cli uncheck <ref>           # uncheck a checkbox
+playwright-cli hover <ref>             # hover over element
+playwright-cli press <key>             # press keyboard key (Enter, Tab, etc.)
+playwright-cli upload <file>           # upload file to file input
+```
+
+### Content Capture
+```bash
+playwright-cli screenshot              # full page screenshot
+playwright-cli screenshot <ref>        # screenshot specific element
+playwright-cli pdf                     # save page as PDF
+playwright-cli eval <expression>       # run JavaScript, return result
+```
+
+### Tabs
+```bash
+playwright-cli tab-list                # list all tabs
+playwright-cli tab-new [url]           # open new tab
+playwright-cli tab-select <index>      # switch to tab
+playwright-cli tab-close [index]       # close tab
+```
+
+### Storage & Cookies
+```bash
+playwright-cli cookie-list             # list all cookies
+playwright-cli cookie-get <name>       # get specific cookie
+playwright-cli cookie-set <name> <val> # set a cookie
+playwright-cli cookie-clear            # clear all cookies
+playwright-cli state-save [file]       # save auth state to file
+playwright-cli state-load <file>       # restore auth state from file
+```
+
+### Session Management
+```bash
+playwright-cli list                    # list all browser sessions
+playwright-cli close                   # close current session
+playwright-cli close-all               # close all sessions
+```
+
+## Headed Mode
+
+To see the browser window (useful for debugging or showing the user):
+
+```bash
+playwright-cli open https://example.com --headed --persistent --profile=~/.octopal/browser-profile
+```
+
+## Vault Integration
+
+When browsing produces useful information:
+
+1. **Save pages as Resources** — If you find a useful article, guide, or reference, save it to the vault using `write_note` in `Resources/`
+2. **Extract and file data** — Use `eval` or `snapshot` to extract text content, then file structured information as knowledge entries
+3. **Save screenshots** — When visual content matters, take a screenshot and note the file path in the vault
+4. **Create knowledge entries** — If you discover information about people, organizations, or terms, save them using `save_knowledge`
+
+## Tips
+
+- Always `snapshot` after navigation or interaction to see the updated page state
+- Element refs (like `e15`) come from snapshots — take a new snapshot to get current refs
+- Use `fill` to replace input content; use `type` to append text
+- For multi-step forms, snapshot between steps to track progress
+- If a site blocks you, try using the browser with a persistent profile — logged-in sessions are less likely to be blocked
+- Use `eval` to extract specific data: `playwright-cli eval "document.title"` or `playwright-cli eval "document.querySelector('.price').textContent"`

--- a/builtin-skills/browser/SKILL.md
+++ b/builtin-skills/browser/SKILL.md
@@ -144,11 +144,6 @@ Use judgment about what's worth saving. Content that's directly relevant to an a
 - **Save knowledge entries** — Use `save_knowledge` only when you encounter a specific person, organization, or term that's relevant to the user's work and worth indexing for future recall. Don't create entries for every entity you encounter on a page.
 - **Screenshots** — Take screenshots when the user asks, or when visual content is essential to the task (e.g., a chart, a UI state). Note the file path in your response.
 
-### `write_note` vs `save_knowledge`
-
-- **`write_note`**: Creates a freeform markdown note at any vault path. Use for articles, research, project docs, session notes.
-- **`save_knowledge`**: Creates a structured, indexed entry in `Resources/Knowledge/{People|Terms|Organizations}/` with auto-generated frontmatter. These entries are automatically recognized and linked in future conversations. Use sparingly — only for entities the user will want to reference again.
-
 ## Tips
 
 - Always `snapshot` after navigation or interaction to see the updated page state

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@playwright/cli": "latest"
+      },
       "devDependencies": {
         "@types/node": "^25.2.1",
         "@types/ws": "^8.18.1",
@@ -425,6 +428,22 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.1.tgz",
+      "integrity": "sha512-9k11ZfDwAfMVDDIuEVW1Wvs8SoDNXIY1dNQ+9C9/SS8ZmElkcxesu5eoL7vNa96ntibUGaq1TM2qQoqvdl/I9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "playwright": "1.59.0-alpha-1771104257000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
@@ -705,6 +724,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -792,6 +825,15 @@
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "license": "MIT",
@@ -836,6 +878,36 @@
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.0-alpha-1771104257000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0-alpha-1771104257000.tgz",
+      "integrity": "sha512-6SCMMMJaDRsSqiKVLmb2nhtLES7iTYawTWWrQK6UdIGNzXi8lka4sLKRec3L4DnTWwddAvCuRn8035dhNiHzbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.0-alpha-1771104257000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.0-alpha-1771104257000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0-alpha-1771104257000.tgz",
+      "integrity": "sha512-YiXup3pnpQUCBMSIW5zx8CErwRx4K6O5Kojkw2BzJui8MazoMUDU6E3xGsb1kzFviEAE09LFQ+y1a0RhIJQ5SA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -1119,6 +1191,7 @@
       "name": "@octopal/connector",
       "version": "0.1.0",
       "dependencies": {
+        "@octopal/core": "*",
         "ws": "^8.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "@types/node": "^25.2.1",
     "@types/ws": "^8.18.1",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@playwright/cli": "latest"
   }
 }


### PR DESCRIPTION
## Summary

Adds browser automation capabilities to Octopal using `@playwright/cli`. The agent can now browse websites, interact with pages, take screenshots, and persist login state — all via shell commands guided by a builtin skill.

## What's included

- **`@playwright/cli` dependency** in root `package.json`
- **`builtin-skills/browser/SKILL.md`** — teaches the agent how to use playwright-cli:
  - When to use browser vs `web_fetch` (interactive flows, blocked sites, JS-heavy SPAs, screenshots)
  - Core workflow: `open → snapshot → interact → screenshot → close`
  - Persistent profile at `~/.octopal/browser-profile/` for cookie/session persistence
  - Named sessions (`-s=NAME`) for parallel browsing
  - Incognito mode (omit `--persistent`)
  - Full command reference: navigation, interaction, content capture, tabs, storage, cookies
  - Vault integration patterns (saving resources, filing knowledge, screenshots)
  - Headed mode for debugging (`--headed`)
- **`.gitignore`** updated to exclude `.playwright-cli/` working directory

## Design decisions

- **Phase 1 approach**: Uses `playwright-cli` via shell rather than building a custom `@octopal/browser` package. The agent already has shell access, so no new TypeScript code is needed.
- **Phase 2 path**: If bot detection becomes a frequent problem in production, we can build `@octopal/browser` with `rebrowser-playwright` (anti-detection patches). The SKILL.md conventions carry over.
- **No new tools**: The agent uses its existing shell/`remote_execute` capabilities to run playwright-cli commands.

## Testing

Verified locally:
- `playwright-cli open` → navigates successfully
- `playwright-cli snapshot` → returns page structure with element refs
- `playwright-cli screenshot` → captures PNG
- `playwright-cli close` → cleanly shuts down
- Build passes (`npm run build`)