### PR TITLE
feat: add voice call support with pluggable STT/TTS providers

### DIFF
--- a/FUTURE_PLANS.md
+++ b/FUTURE_PLANS.md
@@ -49,9 +49,8 @@ Deferred items extracted from 20 Copilot CLI session plans, cross-referenced aga
 - **Status**: ✅ Partially implemented — code-server + VS Code extension provides chat via Agent HQ panel. Dedicated activity panel deferred.
 
 ### Discord Voice Chat
-- **What**: Voice-based interaction via `@discordjs/voice` + opus/sodium, STT/TTS services (Whisper, ElevenLabs)
-- **Blocks**: Voice-based interaction with Octopal
-- **When needed**: Dedicated phase — requires fundamentally different real-time session model
+- **What**: Voice-based interaction via `@discordjs/voice` + opus/sodium, pluggable STT/TTS providers
+- **Status**: ✅ Implemented — `@octopal/voice` package with generic STT/TTS interfaces, VAD, and voice pipeline. Discord voice handler auto-joins channels. Ships with OpenAI Whisper (STT) and OpenAI TTS providers. Configure via `[voice]` in config.toml.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,40 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/node-pre-gyp": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@discordjs/node-pre-gyp/-/node-pre-gyp-0.4.5.tgz",
+      "integrity": "sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@discordjs/opus": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/opus/-/opus-0.10.0.tgz",
+      "integrity": "sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discordjs/node-pre-gyp": "^0.4.5",
+        "node-addon-api": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@discordjs/rest": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
@@ -109,6 +143,25 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
+      "integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.16",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.8.1",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
@@ -421,6 +474,10 @@
       "resolved": "packages/server",
       "link": true
     },
+    "node_modules/@octopal/voice": {
+      "resolved": "packages/voice",
+      "link": true
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "license": "MIT"
@@ -465,6 +522,16 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "license": "MIT",
@@ -482,9 +549,51 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/ajv": {
       "version": "8.17.1",
@@ -515,6 +624,41 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC"
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "license": "MIT",
@@ -530,11 +674,164 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
+      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
+      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/discord-api-types": {
@@ -573,6 +870,20 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "license": "MIT",
@@ -583,11 +894,71 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/fast-decode-uri-component": {
@@ -705,9 +1076,261 @@
         "node": ">=20"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
@@ -792,6 +1415,210 @@
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "license": "MIT",
@@ -804,6 +1631,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pino": {
@@ -836,6 +1672,32 @@
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "license": "MIT"
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -874,6 +1736,18 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
@@ -899,6 +1773,22 @@
     "node_modules/rfdc": {
       "version": "1.4.1",
       "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -966,9 +1856,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/smol-toml": {
       "version": "1.6.0",
@@ -980,6 +1882,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.0.10.tgz",
+      "integrity": "sha512-UIw+0AbpCQRuTJF88JWrZomP4O+PXhlWvdopiAJOsUivTyHTf3korMyStxkZuPngSbBEtEfDdc4ewEd8/T4/lA==",
+      "license": "MIT",
+      "dependencies": {
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
       }
     },
     "node_modules/sonic-boom": {
@@ -1007,6 +1922,50 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "license": "MIT",
@@ -1023,6 +1982,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
@@ -1072,6 +2037,46 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz",
+      "integrity": "sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
@@ -1094,6 +2099,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.3.6",
@@ -1119,6 +2130,7 @@
       "name": "@octopal/connector",
       "version": "0.1.0",
       "dependencies": {
+        "@octopal/core": "*",
         "ws": "^8.0.0"
       },
       "bin": {
@@ -1132,8 +2144,12 @@
       "name": "@octopal/connector-discord",
       "version": "0.1.0",
       "dependencies": {
+        "@discordjs/opus": "^0.10.0",
+        "@discordjs/voice": "^0.19.0",
         "@octopal/core": "*",
-        "discord.js": "^14.0.0"
+        "@octopal/voice": "*",
+        "discord.js": "^14.0.0",
+        "sodium-native": "^5.0.10"
       }
     },
     "packages/core": {
@@ -1152,11 +2168,65 @@
         "@fastify/websocket": "^11.2.0",
         "@octopal/connector-discord": "*",
         "@octopal/core": "*",
+        "@octopal/voice": "*",
         "fastify": "^5.3.3"
       },
       "bin": {
         "octopal-server": "dist/index.js"
       }
+    },
+    "packages/voice": {
+      "name": "@octopal/voice",
+      "version": "0.1.0",
+      "dependencies": {
+        "@octopal/core": "*",
+        "openai": "^4.0.0"
+      }
+    },
+    "packages/voice/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "packages/voice/node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "packages/voice/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     }
   }
 }

--- a/packages/connector-discord/src/index.ts
+++ b/packages/connector-discord/src/index.ts
@@ -5,3 +5,5 @@ export { buildDiscordTools } from "./tools.js";
 export type { DiscordToolDeps } from "./tools.js";
 export { DiscordActivityRenderer } from "./activity.js";
 export type { ActivityChannel } from "./activity.js";
+export { DiscordVoiceHandler } from "./voice/index.js";
+export type { VoiceHandlerOptions } from "./voice/index.js";

--- a/packages/connector-discord/src/voice/audio-adapter.ts
+++ b/packages/connector-discord/src/voice/audio-adapter.ts
@@ -1,0 +1,126 @@
+/**
+ * Discord audio adapter.
+ *
+ * Bridges between Discord.js voice audio (Opus) and the
+ * @octopal/voice pipeline (PCM s16le 48kHz mono).
+ *
+ * - Input: Decodes user's Opus AudioReceiveStream → PCM for the pipeline
+ * - Output: Wraps PCM audio buffer → AudioResource for Discord playback
+ */
+
+import {
+  type VoiceConnection,
+  type AudioReceiveStream,
+  createAudioResource,
+  createAudioPlayer,
+  AudioPlayerStatus,
+  StreamType,
+  EndBehaviorType,
+  type AudioPlayer,
+} from "@discordjs/voice";
+import { Readable } from "node:stream";
+import { createLogger } from "@octopal/core";
+
+const log = createLogger("discord-audio");
+
+/**
+ * Subscribe to a specific user's audio in a voice connection.
+ * Returns a transform that emits PCM s16le 48kHz stereo frames,
+ * which we downmix to mono for the pipeline.
+ */
+export function subscribeToUser(
+  connection: VoiceConnection,
+  userId: string,
+): AudioReceiveStream {
+  const receiver = connection.receiver;
+  const stream = receiver.subscribe(userId, {
+    end: { behavior: EndBehaviorType.Manual },
+    objectMode: false,
+  });
+  return stream;
+}
+
+/**
+ * Convert an Opus AudioReceiveStream to PCM s16le 48kHz mono chunks.
+ * Discord delivers decoded PCM as s16le stereo 48kHz via the opus stream.
+ * We downmix stereo to mono.
+ */
+export function opusStreamToPcmMono(
+  opusStream: AudioReceiveStream,
+  onChunk: (pcm: Buffer) => void,
+): void {
+  // The @discordjs/opus decoder outputs s16le stereo 48kHz
+  opusStream.on("data", (chunk: Buffer) => {
+    const mono = stereoToMono(chunk);
+    onChunk(mono);
+  });
+
+  opusStream.on("error", (err) => {
+    log.error(`Opus stream error: ${err.message}`);
+  });
+}
+
+/** Downmix stereo s16le PCM to mono by averaging L/R channels */
+function stereoToMono(stereo: Buffer): Buffer {
+  const sampleCount = stereo.length / 4; // 2 channels × 2 bytes per sample
+  const mono = Buffer.alloc(sampleCount * 2);
+
+  for (let i = 0; i < sampleCount; i++) {
+    const left = stereo.readInt16LE(i * 4);
+    const right = stereo.readInt16LE(i * 4 + 2);
+    const mixed = Math.round((left + right) / 2);
+    mono.writeInt16LE(Math.max(-32768, Math.min(32767, mixed)), i * 2);
+  }
+
+  return mono;
+}
+
+/**
+ * Play a PCM s16le 48kHz mono buffer through a Discord voice connection.
+ * Returns a promise that resolves when playback completes.
+ */
+export async function playPcmAudio(
+  connection: VoiceConnection,
+  pcmBuffer: Buffer,
+  player?: AudioPlayer,
+): Promise<AudioPlayer> {
+  const audioPlayer = player ?? createAudioPlayer();
+
+  // Convert mono to stereo for Discord (expects s16le stereo 48kHz)
+  const stereo = monoToStereo(pcmBuffer);
+
+  const stream = Readable.from(stereo);
+  const resource = createAudioResource(stream, {
+    inputType: StreamType.Raw,
+  });
+
+  connection.subscribe(audioPlayer);
+  audioPlayer.play(resource);
+
+  return new Promise((resolve, reject) => {
+    const onIdle = () => {
+      audioPlayer.removeListener("error", onError);
+      resolve(audioPlayer);
+    };
+    const onError = (err: Error) => {
+      audioPlayer.removeListener(AudioPlayerStatus.Idle, onIdle);
+      reject(err);
+    };
+    audioPlayer.once(AudioPlayerStatus.Idle, onIdle);
+    audioPlayer.once("error", onError);
+  });
+}
+
+/** Convert mono s16le PCM to stereo by duplicating each sample */
+function monoToStereo(mono: Buffer): Buffer {
+  const sampleCount = mono.length / 2;
+  const stereo = Buffer.alloc(sampleCount * 4);
+
+  for (let i = 0; i < sampleCount; i++) {
+    const sample = mono.readInt16LE(i * 2);
+    stereo.writeInt16LE(sample, i * 4);      // left
+    stereo.writeInt16LE(sample, i * 4 + 2);  // right
+  }
+
+  return stereo;
+}

--- a/packages/connector-discord/src/voice/index.ts
+++ b/packages/connector-discord/src/voice/index.ts
@@ -1,0 +1,2 @@
+export { DiscordVoiceHandler, type VoiceHandlerOptions } from "./voice-handler.js";
+export { subscribeToUser, opusStreamToPcmMono, playPcmAudio } from "./audio-adapter.js";

--- a/packages/connector-discord/src/voice/voice-handler.ts
+++ b/packages/connector-discord/src/voice/voice-handler.ts
@@ -1,0 +1,253 @@
+/**
+ * Discord voice handler.
+ *
+ * Monitors voice state updates and auto-joins voice channels when
+ * an allowed user connects. Creates a VoicePipeline for the session
+ * and manages the lifecycle (join → listen → respond → leave).
+ */
+
+import {
+  joinVoiceChannel,
+  VoiceConnectionStatus,
+  entersState,
+  type VoiceConnection,
+  type AudioReceiveStream,
+  createAudioPlayer,
+  type AudioPlayer,
+} from "@discordjs/voice";
+import type { Client, VoiceState } from "discord.js";
+import { VoicePipeline, type VoicePipelineOptions } from "@octopal/voice";
+import { createLogger, type VoiceConfig } from "@octopal/core";
+import type { ConnectorSessionStore } from "../connector.js";
+import { subscribeToUser, opusStreamToPcmMono, playPcmAudio } from "./audio-adapter.js";
+
+const log = createLogger("discord-voice");
+
+export interface VoiceHandlerOptions {
+  client: Client;
+  sessionStore: ConnectorSessionStore;
+  allowedUsers: Set<string>;
+  voiceConfig?: VoiceConfig;
+  /** Pre-configured pipeline options (STT/TTS providers already resolved) */
+  pipelineOptions: Omit<VoicePipelineOptions, "vad">;
+}
+
+interface ActiveVoiceSession {
+  connection: VoiceConnection;
+  pipeline: VoicePipeline;
+  audioStream: AudioReceiveStream;
+  audioPlayer: AudioPlayer;
+  userId: string;
+  guildId: string;
+  channelId: string;
+}
+
+export class DiscordVoiceHandler {
+  private readonly client: Client;
+  private readonly sessionStore: ConnectorSessionStore;
+  private readonly allowedUsers: Set<string>;
+  private readonly voiceConfig?: VoiceConfig;
+  private readonly pipelineOptions: Omit<VoicePipelineOptions, "vad">;
+
+  /** Active voice sessions keyed by `guildId:userId` */
+  private sessions = new Map<string, ActiveVoiceSession>();
+
+  constructor(options: VoiceHandlerOptions) {
+    this.client = options.client;
+    this.sessionStore = options.sessionStore;
+    this.allowedUsers = options.allowedUsers;
+    this.voiceConfig = options.voiceConfig;
+    this.pipelineOptions = options.pipelineOptions;
+  }
+
+  /** Start listening for voice state changes */
+  start(): void {
+    this.client.on("voiceStateUpdate", (oldState, newState) => {
+      void this.handleVoiceStateUpdate(oldState, newState);
+    });
+    log.info("Voice handler started");
+  }
+
+  /** Disconnect all active voice sessions */
+  async stopAll(): Promise<void> {
+    for (const [key, session] of this.sessions) {
+      await this.endSession(key, session);
+    }
+  }
+
+  private async handleVoiceStateUpdate(
+    oldState: VoiceState,
+    newState: VoiceState,
+  ): Promise<void> {
+    const userId = newState.id;
+    if (!this.allowedUsers.has(userId)) return;
+
+    const oldChannel = oldState.channelId;
+    const newChannel = newState.channelId;
+    const guildId = newState.guild.id;
+    const sessionKey = `${guildId}:${userId}`;
+
+    // User left voice channel
+    if (oldChannel && !newChannel) {
+      const session = this.sessions.get(sessionKey);
+      if (session) {
+        log.info(`User ${userId} left voice channel, ending session`);
+        await this.endSession(sessionKey, session);
+      }
+      return;
+    }
+
+    // User joined a voice channel (or switched channels)
+    if (newChannel && newChannel !== oldChannel) {
+      // End existing session if switching channels
+      const existing = this.sessions.get(sessionKey);
+      if (existing) {
+        await this.endSession(sessionKey, existing);
+      }
+
+      await this.startSession(sessionKey, userId, guildId, newChannel, newState);
+    }
+  }
+
+  private async startSession(
+    sessionKey: string,
+    userId: string,
+    guildId: string,
+    channelId: string,
+    state: VoiceState,
+  ): Promise<void> {
+    try {
+      const guild = state.guild;
+      const channel = guild.channels.cache.get(channelId);
+      if (!channel) {
+        log.error(`Voice channel ${channelId} not found`);
+        return;
+      }
+
+      log.info(`Joining voice channel ${channel.name} for user ${userId}`);
+
+      const connection = joinVoiceChannel({
+        channelId,
+        guildId,
+        adapterCreator: guild.voiceAdapterCreator,
+        selfDeaf: false,
+      });
+
+      // Wait for the connection to be ready
+      await entersState(connection, VoiceConnectionStatus.Ready, 30_000);
+      log.info("Voice connection ready");
+
+      const audioPlayer = createAudioPlayer();
+      connection.subscribe(audioPlayer);
+
+      const agentSessionId = `voice-discord-${userId}`;
+
+      // Create the voice pipeline
+      const pipeline = new VoicePipeline(
+        {
+          ...this.pipelineOptions,
+          vad: {
+            silenceDurationMs: this.voiceConfig?.vadSilenceMs,
+            energyThreshold: this.voiceConfig?.vadEnergyThreshold,
+          },
+        },
+        {
+          onUserSpeech: async (text) => {
+            log.debug(`Processing speech: "${text}"`);
+            const { response } = await this.sessionStore.sendOrRecover(
+              agentSessionId,
+              text,
+              { inactivityTimeoutMs: 120_000 },
+            );
+            return response?.data?.content ?? "Sorry, I couldn't process that.";
+          },
+          onAudioOutput: async (pcmBuffer) => {
+            await playPcmAudio(connection, pcmBuffer, audioPlayer);
+          },
+          onStateChange: (newState) => {
+            log.debug(`Pipeline state: ${newState}`);
+          },
+          onError: (error, phase) => {
+            log.error(`Voice pipeline error (${phase}): ${error.message}`);
+          },
+        },
+      );
+
+      // Subscribe to the user's audio stream
+      const audioStream = subscribeToUser(connection, userId);
+
+      // Feed audio to the pipeline
+      opusStreamToPcmMono(audioStream, (pcm) => {
+        try {
+          pipeline.pushAudio(pcm);
+        } catch (err) {
+          log.error(`Error processing audio chunk: ${err instanceof Error ? err.message : err}`);
+        }
+      });
+
+      pipeline.start();
+
+      const session: ActiveVoiceSession = {
+        connection,
+        pipeline,
+        audioStream,
+        audioPlayer,
+        userId,
+        guildId,
+        channelId,
+      };
+
+      this.sessions.set(sessionKey, session);
+
+      // Handle disconnection
+      connection.on(VoiceConnectionStatus.Disconnected, async () => {
+        log.info("Voice connection disconnected");
+        const s = this.sessions.get(sessionKey);
+        if (s) {
+          await this.endSession(sessionKey, s);
+        }
+      });
+
+      log.info(`Voice session started for user ${userId}`);
+    } catch (error) {
+      log.error(
+        `Failed to start voice session: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
+  private async endSession(
+    key: string,
+    session: ActiveVoiceSession,
+  ): Promise<void> {
+    try {
+      const transcript = session.pipeline.stop();
+
+      // Save transcript to vault if there was any conversation
+      if (!transcript.isEmpty()) {
+        const markdown = transcript.toMarkdown();
+        const agentSessionId = `voice-discord-${session.userId}`;
+        try {
+          await this.sessionStore.sendOrRecover(
+            agentSessionId,
+            `Save this voice call transcript to the vault under Sessions/:\n\n${markdown}`,
+            { inactivityTimeoutMs: 30_000 },
+          );
+          log.info("Voice transcript saved to vault");
+        } catch (err) {
+          log.error(`Failed to save transcript: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+
+      session.audioStream.destroy();
+      session.connection.destroy();
+      this.sessions.delete(key);
+      log.info(`Voice session ended for user ${session.userId}`);
+    } catch (error) {
+      log.error(
+        `Error ending voice session: ${error instanceof Error ? error.message : error}`,
+      );
+      this.sessions.delete(key);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ export { OctopalAgent } from "./agent.js";
 export { VaultManager } from "./vault.js";
 export { ParaManager, ParaCategory } from "./para.js";
 export { TaskManager, type Task, TaskStatus, TaskPriority } from "./tasks.js";
-export { SYSTEM_PROMPT, SETUP_PROMPT } from "./prompts.js";
+export { SYSTEM_PROMPT, SETUP_PROMPT, VOICE_PROMPT_ADDENDUM } from "./prompts.js";
 export { buildVaultTools } from "./tools.js";
 export type { ToolDeps } from "./tools.js";
 export {
@@ -30,7 +30,7 @@ export type { QmdSearchResult, SearchScope } from "./qmd.js";
 export { buildSessionHooks, KNOWLEDGE_TOOLS } from "./hooks.js";
 export type { KnowledgeOperation } from "./hooks.js";
 export { loadConfig, saveConfig, isConfigured, CONFIG_TEMPLATE } from "./config.js";
-export type { OctopalUserConfig, ResolvedConfig, ServerConfig, SchedulerConfig, DiscordConfig } from "./config.js";
+export type { OctopalUserConfig, ResolvedConfig, ServerConfig, SchedulerConfig, DiscordConfig, VoiceConfig, VoiceOpenAIConfig } from "./config.js";
 export { Scheduler } from "./scheduler.js";
 export type { SchedulerOptions } from "./scheduler.js";
 export {

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -26,6 +26,31 @@ You are a *personal* assistant — act like it. When a question seems ambiguous,
 - When responding with information from an external source (web search, vault notes, documents, etc.), always provide inline source links so the user can verify and learn more — like Wikipedia citations. For web sources, include the URL. For vault notes, use [[wikilinks]]. Never present external facts without attribution.
 `;
 
+export const VOICE_PROMPT_ADDENDUM = `
+## Voice Mode
+
+You are currently in a **voice call**. The user is speaking to you through a microphone, and your responses will be spoken aloud via text-to-speech.
+
+### Response Style
+- Keep responses **short and conversational** — 1-3 sentences is ideal
+- Speak naturally, as you would in a real conversation — avoid markdown formatting, bullet points, or code blocks
+- Don't say "here's a link" or reference visual elements — everything must work as spoken audio
+- Use simple sentence structure; avoid parenthetical asides or nested clauses
+- When listing things, use natural language ("first... second... third...") not numbered lists
+- It's okay to be brief — the user can always ask follow-up questions
+
+### Tool Usage
+- You may use **search_vault** and **read_note** to look up context — do this quickly and silently
+- For any **write operations** (save_knowledge, write_note, create_task, etc.) or **heavy operations** (web search, remote execute, etc.), use **spawn_background_task** to handle them asynchronously
+- Tell the user what you're doing: "I'll save that in the background" or "Let me look that up for you"
+- You can check on background tasks with **list_background_tasks** if the user asks about status
+
+### Conversation Flow
+- Acknowledge what the user said before responding substantively
+- If you didn't understand something, say so naturally: "Sorry, I didn't catch that"
+- Don't over-explain — trust that the user will ask if they want more detail
+`;
+
 export const SETUP_PROMPT = `You are the Octopal onboarding assistant. Your job is to help someone set up their personal knowledge vault by having a friendly, conversational interview.
 
 ## Your Goal

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@octopal/core": "*",
     "@octopal/connector-discord": "*",
+    "@octopal/voice": "*",
     "fastify": "^5.3.3",
     "@fastify/websocket": "^11.2.0"
   }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["src"],
   "references": [
     { "path": "../core" },
-    { "path": "../connector-discord" }
+    { "path": "../connector-discord" },
+    { "path": "../voice" }
   ]
 }

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,19 +1,22 @@
 {
-  "name": "@octopal/connector-discord",
+  "name": "@octopal/voice",
   "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@discordjs/opus": "^0.10.0",
-    "@discordjs/voice": "^0.19.0",
     "@octopal/core": "*",
-    "@octopal/voice": "*",
-    "discord.js": "^14.0.0",
-    "sodium-native": "^5.0.10"
+    "openai": "^4.0.0"
   }
 }

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -1,0 +1,22 @@
+export type {
+  AudioFormat,
+  STTProvider,
+  STTResult,
+  STTOptions,
+  TTSProvider,
+  TTSOptions,
+  VADOptions,
+  VADEvent,
+  VoicePipelineOptions,
+  VoicePipelineState,
+  TranscriptEntry,
+  PipelineCallbacks,
+} from "./types.js";
+
+export { VoicePipeline } from "./pipeline.js";
+export { VADDetector } from "./vad.js";
+export { TranscriptAccumulator } from "./transcript.js";
+export { ProviderRegistry } from "./provider-registry.js";
+export { OpenAISTTProvider } from "./providers/openai-stt.js";
+export { OpenAITTSProvider } from "./providers/openai-tts.js";
+export { registerBuiltinProviders } from "./providers/index.js";

--- a/packages/voice/src/pipeline.ts
+++ b/packages/voice/src/pipeline.ts
@@ -1,0 +1,176 @@
+/**
+ * VoicePipeline — orchestrates the full voice interaction loop.
+ *
+ * Audio In → VAD → STT → Agent callback → TTS → Audio Out
+ *
+ * State machine:
+ *   idle → listening → processing → speaking → idle (→ listening ...)
+ *
+ * The pipeline does NOT own the audio transport. Platform adapters
+ * feed PCM chunks via pushAudio() and receive synthesized audio
+ * via the onAudioOutput callback.
+ */
+
+import { createLogger } from "@octopal/core";
+import { VADDetector } from "./vad.js";
+import type {
+  PipelineCallbacks,
+  VADEvent,
+  VoicePipelineOptions,
+  VoicePipelineState,
+} from "./types.js";
+import { PIPELINE_AUDIO_FORMAT } from "./types.js";
+import { TranscriptAccumulator } from "./transcript.js";
+
+const log = createLogger("voice-pipeline");
+
+export class VoicePipeline {
+  private state: VoicePipelineState = "idle";
+  private readonly vad: VADDetector;
+  private readonly options: VoicePipelineOptions;
+  private readonly callbacks: PipelineCallbacks;
+  private readonly transcript = new TranscriptAccumulator();
+  private stopped = false;
+  private processing = false;
+
+  constructor(options: VoicePipelineOptions, callbacks: PipelineCallbacks) {
+    this.options = options;
+    this.callbacks = callbacks;
+
+    const format = options.inputFormat ?? PIPELINE_AUDIO_FORMAT;
+    this.vad = new VADDetector(options.vad, format);
+
+    this.vad.on("vad", (event: VADEvent) => {
+      if (this.stopped) return;
+
+      if (event.type === "speech-start") {
+        log.debug("Speech started");
+      } else if (event.type === "speech-end") {
+        log.debug("Speech ended, processing utterance");
+        void this.handleUtterance(event.audio);
+      }
+    });
+  }
+
+  /** Start the pipeline — begin listening for speech */
+  start(): void {
+    this.stopped = false;
+    this.setState("listening");
+    log.info("Voice pipeline started");
+  }
+
+  /** Stop the pipeline and return the transcript */
+  stop(): TranscriptAccumulator {
+    this.stopped = true;
+    this.vad.reset();
+    this.setState("idle");
+    log.info("Voice pipeline stopped");
+    return this.transcript;
+  }
+
+  /** Feed PCM audio from the platform adapter */
+  pushAudio(chunk: Buffer): void {
+    if (this.stopped || this.state !== "listening") return;
+    this.vad.processChunk(chunk);
+  }
+
+  /** Signal push-to-talk release (optional, platform-specific) */
+  pttRelease(): void {
+    // Force end-of-speech if VAD hasn't triggered yet
+    if (this.state === "listening") {
+      this.vad.reset();
+    }
+  }
+
+  getState(): VoicePipelineState {
+    return this.state;
+  }
+
+  getTranscript(): TranscriptAccumulator {
+    return this.transcript;
+  }
+
+  private setState(newState: VoicePipelineState): void {
+    if (this.state === newState) return;
+    this.state = newState;
+    this.callbacks.onStateChange?.(newState);
+  }
+
+  private async handleUtterance(audio: Buffer): Promise<void> {
+    // Prevent concurrent processing — drop overlapping utterances
+    if (this.processing) {
+      log.debug("Already processing an utterance, dropping");
+      return;
+    }
+    this.processing = true;
+    this.setState("processing");
+
+    try {
+      // STT
+      const format = this.options.inputFormat ?? PIPELINE_AUDIO_FORMAT;
+      const sttResult = await this.options.stt.transcribe(
+        audio,
+        format,
+        this.options.sttOptions,
+      );
+
+      const userText = sttResult.text.trim();
+      if (!userText) {
+        log.debug("STT returned empty text, resuming listening");
+        this.processing = false;
+        this.setState("listening");
+        return;
+      }
+
+      log.info(`User said: "${userText}"`);
+      this.transcript.addEntry("user", userText);
+
+      // Get agent response
+      const responseText = await this.callbacks.onUserSpeech(userText);
+
+      if (this.stopped) {
+        this.processing = false;
+        return;
+      }
+
+      if (!responseText.trim()) {
+        log.debug("Agent returned empty response, resuming listening");
+        this.processing = false;
+        this.setState("listening");
+        return;
+      }
+
+      log.info(`Agent responds: "${responseText.substring(0, 80)}..."`);
+      this.transcript.addEntry("assistant", responseText);
+
+      // TTS
+      this.setState("speaking");
+      const ttsAudio = await this.options.tts.synthesize(
+        responseText,
+        this.options.ttsOptions,
+      );
+
+      if (this.stopped) {
+        this.processing = false;
+        return;
+      }
+
+      await this.callbacks.onAudioOutput(ttsAudio);
+
+      // Resume listening
+      this.processing = false;
+      this.setState("listening");
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const phase = this.state === "processing" ? "stt" : "tts";
+      log.error(`Voice pipeline error (${phase}): ${err.message}`);
+      this.callbacks.onError?.(err, phase as "stt" | "tts");
+
+      // Resume listening after error
+      this.processing = false;
+      if (!this.stopped) {
+        this.setState("listening");
+      }
+    }
+  }
+}

--- a/packages/voice/src/provider-registry.ts
+++ b/packages/voice/src/provider-registry.ts
@@ -1,0 +1,51 @@
+/**
+ * Provider registry for STT and TTS providers.
+ *
+ * Providers register themselves by name. The pipeline resolves
+ * providers from config at startup time.
+ */
+
+import type { STTProvider, TTSProvider } from "./types.js";
+
+export class ProviderRegistry {
+  private sttProviders = new Map<string, STTProvider>();
+  private ttsProviders = new Map<string, TTSProvider>();
+
+  registerSTT(provider: STTProvider): void {
+    this.sttProviders.set(provider.name, provider);
+  }
+
+  registerTTS(provider: TTSProvider): void {
+    this.ttsProviders.set(provider.name, provider);
+  }
+
+  getSTT(name: string): STTProvider {
+    const provider = this.sttProviders.get(name);
+    if (!provider) {
+      const available = [...this.sttProviders.keys()].join(", ") || "(none)";
+      throw new Error(
+        `STT provider "${name}" not found. Available: ${available}`,
+      );
+    }
+    return provider;
+  }
+
+  getTTS(name: string): TTSProvider {
+    const provider = this.ttsProviders.get(name);
+    if (!provider) {
+      const available = [...this.ttsProviders.keys()].join(", ") || "(none)";
+      throw new Error(
+        `TTS provider "${name}" not found. Available: ${available}`,
+      );
+    }
+    return provider;
+  }
+
+  listSTT(): string[] {
+    return [...this.sttProviders.keys()];
+  }
+
+  listTTS(): string[] {
+    return [...this.ttsProviders.keys()];
+  }
+}

--- a/packages/voice/src/providers/index.ts
+++ b/packages/voice/src/providers/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Register all built-in STT/TTS providers.
+ */
+
+import type { ProviderRegistry } from "../provider-registry.js";
+import { OpenAISTTProvider, type OpenAISTTConfig } from "./openai-stt.js";
+import { OpenAITTSProvider, type OpenAITTSConfig } from "./openai-tts.js";
+
+export interface BuiltinProviderConfig {
+  openai?: OpenAISTTConfig & OpenAITTSConfig;
+}
+
+/**
+ * Register all built-in providers with the registry.
+ * Call this at startup before resolving providers from config.
+ */
+export function registerBuiltinProviders(
+  registry: ProviderRegistry,
+  config?: BuiltinProviderConfig,
+): void {
+  registry.registerSTT(new OpenAISTTProvider(config?.openai));
+  registry.registerTTS(new OpenAITTSProvider(config?.openai));
+}

--- a/packages/voice/src/providers/openai-stt.ts
+++ b/packages/voice/src/providers/openai-stt.ts
@@ -1,0 +1,98 @@
+/**
+ * OpenAI Whisper STT provider.
+ *
+ * Transcribes PCM audio using the OpenAI Whisper API.
+ * Converts raw PCM to WAV format for the API call.
+ */
+
+import OpenAI, { toFile } from "openai";
+import type { AudioFormat, STTOptions, STTProvider, STTResult } from "../types.js";
+
+export interface OpenAISTTConfig {
+  /** OpenAI API key. Falls back to OPENAI_API_KEY env var. */
+  apiKey?: string;
+  /** Model name. Default: "whisper-1" */
+  model?: string;
+}
+
+export class OpenAISTTProvider implements STTProvider {
+  readonly name = "openai-whisper";
+  private readonly client: OpenAI;
+  private readonly model: string;
+
+  constructor(config?: OpenAISTTConfig) {
+    this.client = new OpenAI({ apiKey: config?.apiKey });
+    this.model = config?.model ?? "whisper-1";
+  }
+
+  async transcribe(
+    audio: Buffer,
+    format: AudioFormat,
+    options?: STTOptions,
+  ): Promise<STTResult> {
+    const wav = pcmToWav(audio, format);
+    const file = await toFile(wav, "audio.wav", { type: "audio/wav" });
+
+    const response = await this.client.audio.transcriptions.create({
+      model: this.model,
+      file,
+      language: options?.language,
+      prompt: options?.prompt,
+      response_format: "verbose_json",
+    });
+
+    return {
+      text: response.text,
+      segments: response.segments?.map((s) => ({
+        text: s.text,
+        start: s.start,
+        end: s.end,
+      })),
+    };
+  }
+}
+
+/** Convert raw PCM s16le buffer to WAV format */
+function pcmToWav(pcm: Buffer, format: AudioFormat): Buffer {
+  const byteRate = format.sampleRate * format.channels * 2; // 2 bytes per sample (s16le)
+  const blockAlign = format.channels * 2;
+  const headerSize = 44;
+  const dataSize = pcm.length;
+  const fileSize = headerSize + dataSize;
+
+  const header = Buffer.alloc(headerSize);
+  let offset = 0;
+
+  // RIFF header
+  header.write("RIFF", offset);
+  offset += 4;
+  header.writeUInt32LE(fileSize - 8, offset);
+  offset += 4;
+  header.write("WAVE", offset);
+  offset += 4;
+
+  // fmt sub-chunk
+  header.write("fmt ", offset);
+  offset += 4;
+  header.writeUInt32LE(16, offset); // sub-chunk size
+  offset += 4;
+  header.writeUInt16LE(1, offset); // PCM format
+  offset += 2;
+  header.writeUInt16LE(format.channels, offset);
+  offset += 2;
+  header.writeUInt32LE(format.sampleRate, offset);
+  offset += 4;
+  header.writeUInt32LE(byteRate, offset);
+  offset += 4;
+  header.writeUInt16LE(blockAlign, offset);
+  offset += 2;
+  header.writeUInt16LE(16, offset); // bits per sample
+  offset += 2;
+
+  // data sub-chunk
+  header.write("data", offset);
+  offset += 4;
+  header.writeUInt32LE(dataSize, offset);
+
+  return Buffer.concat([header, pcm]);
+}

--- a/packages/voice/src/providers/openai-tts.ts
+++ b/packages/voice/src/providers/openai-tts.ts
@@ -1,0 +1,89 @@
+/**
+ * OpenAI TTS provider.
+ *
+ * Synthesizes text to PCM audio using the OpenAI TTS API.
+ * Requests raw PCM output at the pipeline's standard sample rate.
+ */
+
+import OpenAI from "openai";
+import type { TTSOptions, TTSProvider } from "../types.js";
+import { PIPELINE_AUDIO_FORMAT } from "../types.js";
+
+export interface OpenAITTSConfig {
+  /** OpenAI API key. Falls back to OPENAI_API_KEY env var. */
+  apiKey?: string;
+  /** Model name. Default: "tts-1" */
+  model?: string;
+  /** Default voice. Default: "alloy" */
+  voice?: string;
+}
+
+type TTSVoice = "alloy" | "ash" | "coral" | "echo" | "fable" | "onyx" | "nova" | "sage" | "shimmer";
+
+export class OpenAITTSProvider implements TTSProvider {
+  readonly name = "openai-tts";
+  private readonly client: OpenAI;
+  private readonly model: string;
+  private readonly defaultVoice: TTSVoice;
+
+  constructor(config?: OpenAITTSConfig) {
+    this.client = new OpenAI({ apiKey: config?.apiKey });
+    this.model = config?.model ?? "tts-1";
+    this.defaultVoice = (config?.voice ?? "alloy") as TTSVoice;
+  }
+
+  async synthesize(text: string, options?: TTSOptions): Promise<Buffer> {
+    const voice = (options?.voice ?? this.defaultVoice) as TTSVoice;
+    const speed = options?.speed ?? 1.0;
+
+    const response = await this.client.audio.speech.create({
+      model: this.model,
+      voice,
+      input: text,
+      speed,
+      response_format: "pcm", // raw s16le 24kHz mono
+    });
+
+    const rawPcm = Buffer.from(await response.arrayBuffer());
+
+    // OpenAI TTS returns 24kHz PCM; resample to pipeline format (48kHz) if needed
+    if (PIPELINE_AUDIO_FORMAT.sampleRate === 24_000) {
+      return rawPcm;
+    }
+
+    return resample(rawPcm, 24_000, PIPELINE_AUDIO_FORMAT.sampleRate);
+  }
+}
+
+/** Simple linear interpolation resampler for s16le mono PCM */
+function resample(
+  input: Buffer,
+  fromRate: number,
+  toRate: number,
+): Buffer {
+  if (fromRate === toRate) return input;
+
+  const ratio = toRate / fromRate;
+  const inputSamples = input.length / 2;
+  const outputSamples = Math.floor(inputSamples * ratio);
+  const output = Buffer.alloc(outputSamples * 2);
+
+  for (let i = 0; i < outputSamples; i++) {
+    const srcPos = i / ratio;
+    const srcIndex = Math.floor(srcPos);
+    const frac = srcPos - srcIndex;
+
+    const s0 = input.readInt16LE(Math.min(srcIndex, inputSamples - 1) * 2);
+    const s1 = input.readInt16LE(
+      Math.min(srcIndex + 1, inputSamples - 1) * 2,
+    );
+
+    const interpolated = Math.round(s0 + frac * (s1 - s0));
+    output.writeInt16LE(
+      Math.max(-32768, Math.min(32767, interpolated)),
+      i * 2,
+    );
+  }
+
+  return output;
+}

--- a/packages/voice/src/transcript.ts
+++ b/packages/voice/src/transcript.ts
@@ -1,0 +1,72 @@
+/**
+ * Transcript accumulator for voice sessions.
+ *
+ * Logs timestamped user/assistant turns during a voice call.
+ * On session end, formats the transcript as markdown for vault storage.
+ */
+
+import type { TranscriptEntry } from "./types.js";
+
+export class TranscriptAccumulator {
+  private readonly entries: TranscriptEntry[] = [];
+  private readonly startTime = new Date();
+
+  addEntry(role: "user" | "assistant", text: string): void {
+    this.entries.push({ role, text, timestamp: new Date() });
+  }
+
+  getEntries(): readonly TranscriptEntry[] {
+    return this.entries;
+  }
+
+  isEmpty(): boolean {
+    return this.entries.length === 0;
+  }
+
+  /** Format the transcript as markdown suitable for vault storage */
+  toMarkdown(): string {
+    const dateStr = this.startTime.toISOString().split("T")[0];
+    const timeStr = this.startTime.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+
+    const lines: string[] = [
+      `# Voice Call — ${dateStr} ${timeStr}`,
+      "",
+      `**Started:** ${this.startTime.toISOString()}`,
+      `**Duration:** ${this.formatDuration()}`,
+      `**Turns:** ${this.entries.length}`,
+      "",
+      "---",
+      "",
+    ];
+
+    for (const entry of this.entries) {
+      const ts = entry.timestamp.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      });
+      const speaker = entry.role === "user" ? "🗣️ User" : "🤖 Octopal";
+      lines.push(`**${speaker}** (${ts}):`);
+      lines.push(entry.text);
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+
+  private formatDuration(): string {
+    const endTime =
+      this.entries.length > 0
+        ? this.entries[this.entries.length - 1].timestamp
+        : this.startTime;
+    const durationMs = endTime.getTime() - this.startTime.getTime();
+    const minutes = Math.floor(durationMs / 60_000);
+    const seconds = Math.floor((durationMs % 60_000) / 1000);
+    return `${minutes}m ${seconds}s`;
+  }
+}

--- a/packages/voice/src/types.ts
+++ b/packages/voice/src/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Core type definitions for the @octopal/voice package.
+ *
+ * These interfaces define the contracts for STT/TTS providers,
+ * voice activity detection, and the voice pipeline.
+ */
+
+// ── Audio Format ─────────────────────────────────────────────────
+
+export interface AudioFormat {
+  /** Sample rate in Hz (e.g. 48000) */
+  sampleRate: number;
+  /** Number of audio channels (1 = mono) */
+  channels: number;
+  /** PCM encoding */
+  encoding: "s16le";
+}
+
+/** Standard format used internally by the voice pipeline */
+export const PIPELINE_AUDIO_FORMAT: AudioFormat = {
+  sampleRate: 48_000,
+  channels: 1,
+  encoding: "s16le",
+};
+
+// ── STT (Speech-to-Text) ────────────────────────────────────────
+
+export interface STTResult {
+  /** Transcribed text */
+  text: string;
+  /** Confidence score (0–1), if available */
+  confidence?: number;
+  /** Word/segment-level timing, if available */
+  segments?: Array<{ text: string; start: number; end: number }>;
+}
+
+export interface STTOptions {
+  /** Language hint (e.g. "en") */
+  language?: string;
+  /** Optional prompt/context to improve transcription accuracy */
+  prompt?: string;
+}
+
+export interface STTProvider {
+  readonly name: string;
+  /** Transcribe a PCM audio buffer to text */
+  transcribe(
+    audio: Buffer,
+    format: AudioFormat,
+    options?: STTOptions,
+  ): Promise<STTResult>;
+}
+
+// ── TTS (Text-to-Speech) ────────────────────────────────────────
+
+export interface TTSOptions {
+  /** Voice identifier (provider-specific) */
+  voice?: string;
+  /** Speech speed multiplier (1.0 = normal) */
+  speed?: number;
+}
+
+export interface TTSProvider {
+  readonly name: string;
+  /**
+   * Synthesize text to PCM audio.
+   * Returns a buffer in the pipeline's standard audio format (48kHz mono s16le).
+   */
+  synthesize(text: string, options?: TTSOptions): Promise<Buffer>;
+}
+
+// ── VAD (Voice Activity Detection) ──────────────────────────────
+
+export interface VADOptions {
+  /** Silence duration (ms) before considering speech ended. Default: 800 */
+  silenceDurationMs?: number;
+  /** RMS energy threshold to detect speech (0–1 normalized). Default: 0.01 */
+  energyThreshold?: number;
+  /** Minimum speech duration (ms) to emit an utterance. Default: 200 */
+  minSpeechDurationMs?: number;
+}
+
+export type VADEvent =
+  | { type: "speech-start" }
+  | { type: "speech-end"; audio: Buffer };
+
+// ── Voice Pipeline ──────────────────────────────────────────────
+
+export type VoicePipelineState =
+  | "idle"
+  | "listening"
+  | "processing"
+  | "speaking";
+
+export interface PipelineCallbacks {
+  /** Called when user speech is transcribed. Must return the agent's text response. */
+  onUserSpeech(text: string): Promise<string>;
+  /** Called when TTS audio is ready to play */
+  onAudioOutput(audio: Buffer): Promise<void>;
+  /** Called on pipeline state changes */
+  onStateChange?(state: VoicePipelineState): void;
+  /** Called on errors (pipeline continues running) */
+  onError?(error: Error, phase: "stt" | "tts" | "vad"): void;
+}
+
+export interface VoicePipelineOptions {
+  stt: STTProvider;
+  tts: TTSProvider;
+  vad?: VADOptions;
+  /** Audio format of incoming audio. Default: 48kHz mono s16le */
+  inputFormat?: AudioFormat;
+  /** TTS voice/speed options */
+  ttsOptions?: TTSOptions;
+  /** STT options (language, prompt) */
+  sttOptions?: STTOptions;
+}
+
+// ── Transcript ──────────────────────────────────────────────────
+
+export interface TranscriptEntry {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: Date;
+}

--- a/packages/voice/src/vad.ts
+++ b/packages/voice/src/vad.ts
@@ -1,0 +1,116 @@
+/**
+ * Energy-based Voice Activity Detection (VAD).
+ *
+ * Processes PCM s16le audio chunks and detects speech boundaries
+ * by tracking RMS energy levels. Emits speech-start when energy
+ * exceeds threshold, and speech-end (with buffered audio) after
+ * sustained silence.
+ */
+
+import { EventEmitter } from "node:events";
+import type { VADOptions, VADEvent, AudioFormat } from "./types.js";
+import { PIPELINE_AUDIO_FORMAT } from "./types.js";
+
+const DEFAULT_SILENCE_MS = 800;
+const DEFAULT_ENERGY_THRESHOLD = 0.01;
+const DEFAULT_MIN_SPEECH_MS = 200;
+
+// s16le: 2 bytes per sample
+const BYTES_PER_SAMPLE = 2;
+// Max absolute value for signed 16-bit
+const S16_MAX = 32768;
+
+export class VADDetector extends EventEmitter {
+  private readonly silenceDurationMs: number;
+  private readonly energyThreshold: number;
+  private readonly minSpeechDurationMs: number;
+  private readonly sampleRate: number;
+
+  private isSpeaking = false;
+  private speechBuffers: Buffer[] = [];
+  private silenceSamples = 0;
+  private speechSamples = 0;
+
+  constructor(options?: VADOptions, format?: AudioFormat) {
+    super();
+    this.silenceDurationMs = options?.silenceDurationMs ?? DEFAULT_SILENCE_MS;
+    this.energyThreshold = options?.energyThreshold ?? DEFAULT_ENERGY_THRESHOLD;
+    this.minSpeechDurationMs =
+      options?.minSpeechDurationMs ?? DEFAULT_MIN_SPEECH_MS;
+    this.sampleRate = format?.sampleRate ?? PIPELINE_AUDIO_FORMAT.sampleRate;
+  }
+
+  /** Process a chunk of PCM s16le audio */
+  processChunk(chunk: Buffer): void {
+    const energy = this.computeRMS(chunk);
+    const chunkSamples = chunk.length / BYTES_PER_SAMPLE;
+    const isSpeech = energy >= this.energyThreshold;
+
+    if (isSpeech) {
+      this.silenceSamples = 0;
+
+      if (!this.isSpeaking) {
+        this.isSpeaking = true;
+        this.speechSamples = 0;
+        this.speechBuffers = [];
+        this.emit("vad", { type: "speech-start" } satisfies VADEvent);
+      }
+
+      this.speechSamples += chunkSamples;
+      this.speechBuffers.push(chunk);
+    } else if (this.isSpeaking) {
+      // Still collecting during silence gap
+      this.speechBuffers.push(chunk);
+      this.silenceSamples += chunkSamples;
+
+      const silenceMs = (this.silenceSamples / this.sampleRate) * 1000;
+      if (silenceMs >= this.silenceDurationMs) {
+        this.endSpeech();
+      }
+    }
+    // If not speaking and no speech detected, discard
+  }
+
+  /** Reset detector state */
+  reset(): void {
+    this.isSpeaking = false;
+    this.speechBuffers = [];
+    this.silenceSamples = 0;
+    this.speechSamples = 0;
+  }
+
+  private endSpeech(): void {
+    const speechDurationMs = (this.speechSamples / this.sampleRate) * 1000;
+
+    if (speechDurationMs >= this.minSpeechDurationMs) {
+      // Trim trailing silence from the buffer
+      const silenceBytes = this.silenceSamples * BYTES_PER_SAMPLE;
+      const fullAudio = Buffer.concat(this.speechBuffers);
+      const trimmedAudio = fullAudio.subarray(
+        0,
+        fullAudio.length - silenceBytes,
+      );
+
+      this.emit("vad", {
+        type: "speech-end",
+        audio: trimmedAudio,
+      } satisfies VADEvent);
+    }
+
+    this.reset();
+  }
+
+  /** Compute RMS energy of a PCM s16le buffer, normalized to 0–1 */
+  private computeRMS(chunk: Buffer): number {
+    const numSamples = chunk.length / BYTES_PER_SAMPLE;
+    if (numSamples === 0) return 0;
+
+    let sumSquares = 0;
+    for (let i = 0; i < chunk.length; i += BYTES_PER_SAMPLE) {
+      const sample = chunk.readInt16LE(i) / S16_MAX;
+      sumSquares += sample * sample;
+    }
+
+    return Math.sqrt(sumSquares / numSamples);
+  }
+}

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -5,5 +5,7 @@
     "rootDir": "./src"
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }, { "path": "../voice" }]
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     { "path": "packages/cli" },
     { "path": "packages/server" },
     { "path": "packages/connector-discord" },
-    { "path": "packages/connector" }
+    { "path": "packages/connector" },
+    { "path": "packages/voice" }
   ],
   "files": []
 }


### PR DESCRIPTION
## Summary

Add real-time voice conversation support to Octopal, starting with Discord voice channels. The design uses a platform-agnostic voice pipeline that can be extended to other voice platforms (WebRTC, Twilio, etc.) in the future.

## New Package: `@octopal/voice`

Platform-agnostic voice pipeline with:
- **Pluggable STT/TTS providers** — generic `STTProvider` and `TTSProvider` interfaces with a `ProviderRegistry` for config-driven lookup
- **Built-in providers** — OpenAI Whisper (STT) and OpenAI TTS, with PCM↔WAV conversion and 24kHz→48kHz resampling
- **Voice Activity Detection** — energy-based `VADDetector` for turn-taking, with configurable silence duration and energy threshold
- **VoicePipeline** — state machine (`idle` → `listening` → `processing` → `speaking`) with concurrency guard to prevent overlapping STT/TTS calls
- **TranscriptAccumulator** — timestamped conversation log, formatted as markdown for vault storage

## Discord Voice Integration

In `@octopal/connector-discord`:
- **Auto-join** — `DiscordVoiceHandler` monitors `voiceStateUpdate` and auto-joins when an allowed user enters a voice channel
- **Audio adapter** — Opus↔PCM conversion with stereo/mono handling for Discord.js voice streams
- **Session lifecycle** — handles disconnect, channel switches, cleanup, and transcript saving
- **Single user** — one allowed user per voice channel (personal assistant mode)

## Voice-Specific Agent Mode

- **`VOICE_PROMPT_ADDENDUM`** — concise, spoken-friendly response instructions (no markdown, 1-3 sentences)
- **`mode: "voice"`** on `createSession()` — filters tools to vault search + background task management only
- **Background dispatch** — heavy operations (writes, web search, etc.) go through `spawn_background_task`

## Configuration

New `[voice]` section in `config.toml`:
```toml
[voice]
sttProvider = "openai-whisper"
ttsProvider = "openai-tts"
vadSilenceMs = 800
vadEnergyThreshold = 0.01

[voice.openai]
ttsVoice = "alloy"
```

Voice activates automatically when both `sttProvider` and `ttsProvider` are configured alongside Discord.

## Changes

| Area | Files | What |
|------|-------|------|
| New package | `packages/voice/` (14 files) | Voice pipeline, VAD, STT/TTS providers, transcript |
| Discord | `packages/connector-discord/src/voice/` (3 files) | Audio adapter, voice handler, exports |
| Discord | `packages/connector-discord/src/connector.ts` | `enableVoice()`, `GuildVoiceStates` intent |
| Core | `packages/core/src/agent.ts` | `mode: "voice"` option, tool filtering |
| Core | `packages/core/src/prompts.ts` | `VOICE_PROMPT_ADDENDUM` |
| Core | `packages/core/src/config.ts` | `VoiceConfig`, `VoiceOpenAIConfig` types, config loading |
| Server | `packages/server/src/server.ts` | Voice provider registry init, `enableVoice()` call |
| Docs | `FUTURE_PLANS.md` | Mark Discord Voice as implemented |

## Future Work

- Barge-in (interrupt Octopal while speaking)
- Multi-user voice calls (speaker diarization)
- Additional STT/TTS providers (ElevenLabs, local Whisper)
- WebRTC voice platform adapter
- Push-to-talk platform signal support